### PR TITLE
Add short logicals

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ is4ItemArray([1, 2, 3, 4, 5]); // false
 You can compose p expressions easily.
 
 ```js
-//
-
 const isOnlyLowerCase = p`String & !Nc & !Uc`;
 const hasExtendedChars = p`String & Xc`;
 
@@ -112,8 +110,6 @@ isValidUser({ username: "ryardley", password: "Hello1234!", age: 17 }); //false
 isValidUser({ username: "Ryardley", password: "Hello1234!", age: 21 }); //false
 isValidUser({ username: "123456", password: "Hello1234!", age: 21 }); //false
 isValidUser({ username: "ryardley", password: "12345678", age: 21 }); //false
-
-//
 ```
 
 The more complex things get, the more PDSL shines see the above example in vanilla JS:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const is4ItemArray = input => Array.isArray(input) && input.length === 4;
 _PDSL:_
 
 ```js
-const is4ItemArray = p`Array && { length: 4 }`;
+const is4ItemArray = p`Array & { length: 4 }`;
 ```
 
 ```js
@@ -98,12 +98,12 @@ You can compose p expressions easily.
 ```js
 //
 
-const isOnlyLowerCase = p`String && !Nc && !Uc`;
-const hasExtendedChars = p`String && Xc`;
+const isOnlyLowerCase = p`String & !Nc & !Uc`;
+const hasExtendedChars = p`String & Xc`;
 
 const isValidUser = p`{
-  username: ${isOnlyLowerCase} && {length: 5 < < 9 },
-  password: ${hasExtendedChars} && {length: > 8},
+  username: ${isOnlyLowerCase} & {length: 5 < < 9 },
+  password: ${hasExtendedChars} & {length: > 8},
   age: > 17
 }`;
 
@@ -143,7 +143,7 @@ const isKitchenSinc = p`
   {
     type: ${/^.+foo$/},
     payload: {
-      email: Email && { length: > 5 },
+      email: Email & { length: > 5 },
       arr: ![6],
       foo: !true,
       num: -4 < < 100,
@@ -235,14 +235,14 @@ const isNull = p`null`;
 
 ### Operators
 
-You can use familiar JS boolean operators and brackets such as `!`, `&&`, `||`, `(`, or `)`:
+You can use familiar JS boolean operators and brackets such as `!`, `&&`, `||`, `(`, or `)` as well as the shorter `&` and `|`:
 
 ```js
 const isNotNil = p`!(null||undefined)`;
 ```
 
 ```js
-const is6CharString = p`String && { length: 6 }`;
+const is6CharString = p`String & { length: 6 }`;
 ```
 
 ### Object properties
@@ -259,7 +259,7 @@ validate({ name: 20 }); // false
 This applies to checking properties of all javascript objects. For example to check a string's length:
 
 ```js
-const validate = p`String && { length: 7 }`; // value && typeof value.name === 'string' && value.name.length === 7;
+const validate = p`String & { length: 7 }`; // value && typeof value.name === 'string' && value.name.length === 7;
 
 validate("Rudi"); // false
 validate("Yardley"); // true
@@ -335,23 +335,23 @@ pred(String)("Hello"); // true
 
 Available helpers:
 
-| Helper                                                     | Description                                 | pdsl operator  |
-| ---------------------------------------------------------- | ------------------------------------------- | -------------- |
-| [and](https://ryardley.github.io/pdsl/global.html#and)     | Logical AND                                 | `a && b`       |
-| [btw](https://ryardley.github.io/pdsl/global.html#btw)     | Between                                     | `10 < < 100`   |
-| [btwe](https://ryardley.github.io/pdsl/global.html#btwe)   | Between or equals                           | `10 <= <= 100` |
-| [deep](https://ryardley.github.io/pdsl/global.html#deep)   | Deep equality                               |                |
-| [gt](https://ryardley.github.io/pdsl/global.html#gt)       | Greater than                                | `> 5`          |
-| [gte](https://ryardley.github.io/pdsl/global.html#gte)     | Greater than or equals                      | `>= 5`         |
-| [holds](https://ryardley.github.io/pdsl/global.html#holds) | Array holds input                           | `[4,3]`        |
-| [lt](https://ryardley.github.io/pdsl/global.html#lt)       | Less than                                   | `< 5`          |
-| [lte](https://ryardley.github.io/pdsl/global.html#lte)     | Less than equals                            | `<= 5`         |
-| [not](https://ryardley.github.io/pdsl/global.html#not)     | Logical NOT                                 | `!6`           |
-| [or](https://ryardley.github.io/pdsl/global.html#or)       | Logical OR                                  | `a || b`       |
-| [pred](https://ryardley.github.io/pdsl/global.html#pred)   | Select the correct predicate based on input | `${}`          |
-| [prim](https://ryardley.github.io/pdsl/global.html#prim)   | Primative typeof checking                   | `Array` etc.   |
-| [regx](https://ryardley.github.io/pdsl/global.html#regx)   | Regular expression predicate                | `${/^foo/}`    |
-| [val](https://ryardley.github.io/pdsl/global.html#val)     | Strict equality                             |                |
+| Helper                                                     | Description                                 | pdsl operator       |
+| ---------------------------------------------------------- | ------------------------------------------- | ------------------- |
+| [and](https://ryardley.github.io/pdsl/global.html#and)     | Logical AND                                 | `a & b` or `a && b` |
+| [btw](https://ryardley.github.io/pdsl/global.html#btw)     | Between                                     | `10 < < 100`        |
+| [btwe](https://ryardley.github.io/pdsl/global.html#btwe)   | Between or equals                           | `10 <= <= 100`      |
+| [deep](https://ryardley.github.io/pdsl/global.html#deep)   | Deep equality                               |                     |
+| [gt](https://ryardley.github.io/pdsl/global.html#gt)       | Greater than                                | `> 5`               |
+| [gte](https://ryardley.github.io/pdsl/global.html#gte)     | Greater than or equals                      | `>= 5`              |
+| [holds](https://ryardley.github.io/pdsl/global.html#holds) | Array holds input                           | `[4,3]`             |
+| [lt](https://ryardley.github.io/pdsl/global.html#lt)       | Less than                                   | `< 5`               |
+| [lte](https://ryardley.github.io/pdsl/global.html#lte)     | Less than equals                            | `<= 5`              |
+| [not](https://ryardley.github.io/pdsl/global.html#not)     | Logical NOT                                 | `!6`                |
+| [or](https://ryardley.github.io/pdsl/global.html#or)       | Logical OR                                  | `a || b` or `a | b` |
+| [pred](https://ryardley.github.io/pdsl/global.html#pred)   | Select the correct predicate based on input | `${}`               |
+| [prim](https://ryardley.github.io/pdsl/global.html#prim)   | Primative typeof checking                   | `Array` etc.        |
+| [regx](https://ryardley.github.io/pdsl/global.html#regx)   | Regular expression predicate                | `${/^foo/}`         |
+| [val](https://ryardley.github.io/pdsl/global.html#val)     | Strict equality                             |                     |
 
 For the helper docs please chec the [helper docs](https://ryardley.github.io/pdsl/index.html).
 
@@ -371,10 +371,6 @@ I had a need for it when filtering on events in an app working with my event bus
 
 #### How does this work?
 
-<<<<<<< HEAD
-It is comprised of a [lexer](https://en.wikipedia.org/wiki/Lexical_analysis) a [parser](https://en.wikipedia.org/wiki/Parsing#Parser) and a [code generator](https://en.wikipedia.org/wiki/Code_generation_(compiler)). I used a version of the [shunting yard algorhythm](https://en.wikipedia.org/wiki/Shunting-yard_algorithm) to create the basic parser storing the output in [RPN](https://en.wikipedia.org/wiki/Reverse_Polish_notation) but using objects in an array. I then added parsing for Varadic Functions. A lot of it was by trial and error. 
+It is comprised of a [lexer](https://en.wikipedia.org/wiki/Lexical_analysis) a [parser](https://en.wikipedia.org/wiki/Parsing#Parser) and a [code generator](<https://en.wikipedia.org/wiki/Code_generation_(compiler)>). I used a version of the [shunting yard algorhythm](https://en.wikipedia.org/wiki/Shunting-yard_algorithm) to create the basic parser storing the output in [RPN](https://en.wikipedia.org/wiki/Reverse_Polish_notation) but using objects in an array. I then added parsing for Varadic Functions. A lot of it was by trial and error.
 
-I am certain there are better ways to do it. If you know how to do it better, faster, stronger or smaller, retaining semantic flexability and with no dependencies - I want to learn  - please file an issue!
-=======
-It is comprised of a [lexer](https://en.wikipedia.org/wiki/Lexical_analysis) a [parser](https://en.wikipedia.org/wiki/Parsing#Parser) and a [code generator](<https://en.wikipedia.org/wiki/Code_generation_(compiler)>). I used a version of the [shunting yard algorhythm](https://en.wikipedia.org/wiki/Shunting-yard_algorithm) to create the basic parser storing the output in [RPN](https://en.wikipedia.org/wiki/Reverse_Polish_notation) but using objects in an array. I then added parsing for Varadic Functions. A lot of it was by trial and error. I am certain there are better ways to do it. If you know how I can do so with no dependencies I want to hear about it!
->>>>>>> Add short logical operators
+I am certain there are better ways to do it. If you know how to do it better, faster, stronger or smaller, retaining semantic flexability and with no dependencies - I want to learn - please file an issue!

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ _Vanilla JS:_
 const hasName = input => input && input.name;
 ```
 
-__PDSL:__
+**PDSL:**
 
 ```js
 const hasName = p`{name}`;
 ```
 
 ```js
-hasName({name: "A name"}); // true
-hasName({name: true}); // true
+hasName({ name: "A name" }); // true
+hasName({ name: true }); // true
 hasName({}); // false
 ```
 
@@ -42,7 +42,7 @@ _Vanilla JS:_
 const isRoughlyPi = input => input > 3.1415 && input < 3.1416;
 ```
 
-__PDSL:__
+**PDSL:**
 
 ```js
 const isRoughlyPi = p`3.1415< <3.1416`;
@@ -61,7 +61,7 @@ _Vanilla JS:_
 const isNumeric = input => typeof input === 'number`;
 ```
 
-__PDSL:__
+**PDSL:**
 
 ```js
 const isNumeric = p`Number`;
@@ -87,8 +87,8 @@ const is4ItemArray = p`Array && { length: 4 }`;
 ```
 
 ```js
-is4ItemArray([1,2,3,4]); // true
-is4ItemArray([1,2,3,4,5]); // false
+is4ItemArray([1, 2, 3, 4]); // true
+is4ItemArray([1, 2, 3, 4, 5]); // false
 ```
 
 ### User validation
@@ -96,6 +96,8 @@ is4ItemArray([1,2,3,4,5]); // false
 You can compose p expressions easily.
 
 ```js
+//
+
 const isOnlyLowerCase = p`String && !Nc && !Uc`;
 const hasExtendedChars = p`String && Xc`;
 
@@ -110,24 +112,25 @@ isValidUser({ username: "ryardley", password: "Hello1234!", age: 17 }); //false
 isValidUser({ username: "Ryardley", password: "Hello1234!", age: 21 }); //false
 isValidUser({ username: "123456", password: "Hello1234!", age: 21 }); //false
 isValidUser({ username: "ryardley", password: "12345678", age: 21 }); //false
+
+//
 ```
 
 The more complex things get, the more PDSL shines see the above example in vanilla JS:
 
 ```js
 const isValidUser = input => {
-  input && 
-  input.username &&
-  typeof input.username === 'string' &&
-  !input.username.match(/[^0-9]/) &&
-  !input.username.match(/[^A-Z]/) &&
-  input.username.length > 5 &&
-  input.username.length < 9 &&
-  typeof input.password === 'string' &&
-  input.password.match(/[^a-zA-Z0-9]/)
-  input.password.length > 8 &&
-  input.age > 17
-}
+  input &&
+    input.username &&
+    typeof input.username === "string" &&
+    !input.username.match(/[^0-9]/) &&
+    !input.username.match(/[^A-Z]/) &&
+    input.username.length > 5 &&
+    input.username.length < 9 &&
+    typeof input.password === "string" &&
+    input.password.match(/[^a-zA-Z0-9]/);
+  input.password.length > 8 && input.age > 17;
+};
 ```
 
 ### Complex Example
@@ -176,7 +179,7 @@ isKitchenSinc({
 
 ## Disclaimer
 
-This should work but there is a chance you may find bugs that are not covered by our test suite. Not all safety checks are in place and you may find issues around this. Please help this open source project by creating issues. Pull requests appreciated! Feel free to help with open issues. This Syntax is DRAFT and we are open for RFCs on the syntax. All feedback welcome. If you want to be a maintainer just ask. 
+This should work but there is a chance you may find bugs that are not covered by our test suite. Not all safety checks are in place and you may find issues around this. Please help this open source project by creating issues. Pull requests appreciated! Feel free to help with open issues. This Syntax is DRAFT and we are open for RFCs on the syntax. All feedback welcome. If you want to be a maintainer just ask.
 
 ## Installation
 
@@ -364,10 +367,14 @@ Predicate Domain Specific Language.
 
 #### Why did you write this?
 
-I had a need for it when filtering on events in an app working with my event bus framework [ts-bus](https://github.com/ryardley/ts-bus). I also wanted to learn to create a compiler from scratch. 
+I had a need for it when filtering on events in an app working with my event bus framework [ts-bus](https://github.com/ryardley/ts-bus). I also wanted to learn to create a compiler from scratch.
 
-#### How does this work? 
+#### How does this work?
 
+<<<<<<< HEAD
 It is comprised of a [lexer](https://en.wikipedia.org/wiki/Lexical_analysis) a [parser](https://en.wikipedia.org/wiki/Parsing#Parser) and a [code generator](https://en.wikipedia.org/wiki/Code_generation_(compiler)). I used a version of the [shunting yard algorhythm](https://en.wikipedia.org/wiki/Shunting-yard_algorithm) to create the basic parser storing the output in [RPN](https://en.wikipedia.org/wiki/Reverse_Polish_notation) but using objects in an array. I then added parsing for Varadic Functions. A lot of it was by trial and error. 
 
 I am certain there are better ways to do it. If you know how to do it better, faster, stronger or smaller, retaining semantic flexability and with no dependencies - I want to learn  - please file an issue!
+=======
+It is comprised of a [lexer](https://en.wikipedia.org/wiki/Lexical_analysis) a [parser](https://en.wikipedia.org/wiki/Parsing#Parser) and a [code generator](<https://en.wikipedia.org/wiki/Code_generation_(compiler)>). I used a version of the [shunting yard algorhythm](https://en.wikipedia.org/wiki/Shunting-yard_algorithm) to create the basic parser storing the output in [RPN](https://en.wikipedia.org/wiki/Reverse_Polish_notation) but using objects in an array. I then added parsing for Varadic Functions. A lot of it was by trial and error. I am certain there are better ways to do it. If you know how I can do so with no dependencies I want to hear about it!
+>>>>>>> Add short logical operators

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ With `pdsl` we can easily visualize the expected input's structure and intent us
 
 ## Examples
 
+### Quick nil check
+
+_Vanilla JS:_
+
+```js
+const notNil = input => input !== null && input !== undefined;
+```
+
+```js
+const notNil = p`!(null | undefined)`;
+
+notNil("something"); // true
+notNil(false); // true
+notNil(0); // true
+notNil(null); // false
+notNil(undefined); // false
+```
+
 ### Object has truthy property
 
 _Vanilla JS:_

--- a/grammar.js
+++ b/grammar.js
@@ -25,6 +25,8 @@ const tokens = {
   NOT: "\\!",
   AND: "\\&\\&",
   OR: "\\|\\|",
+  AND_SHORT: "\\&",
+  OR_SHORT: "\\|",
   BTW: "\\<\\s\\<",
   GT: "\\>",
   GTE: "\\>\\=",
@@ -71,13 +73,6 @@ const grammar = {
   [tokens.TRUE]: token => ({
     type: "BooleanLiteral",
     token: token === "true",
-    toString() {
-      return token;
-    }
-  }),
-  [tokens.FALSE]: token => ({
-    type: "BooleanLiteral",
-    token: token === "false",
     toString() {
       return token;
     }
@@ -289,8 +284,28 @@ const grammar = {
       return token;
     }
   }),
+  [tokens.AND_SHORT]: token => ({
+    type: "Operator",
+    token,
+    arity: 2,
+    runtime: and,
+    prec: 20,
+    toString() {
+      return token;
+    }
+  }),
 
   [tokens.OR]: token => ({
+    type: "Operator",
+    token,
+    arity: 2,
+    runtime: or,
+    prec: 30,
+    toString() {
+      return token;
+    }
+  }),
+  [tokens.OR_SHORT]: token => ({
     type: "Operator",
     token,
     arity: 2,

--- a/index.test.js
+++ b/index.test.js
@@ -284,3 +284,13 @@ it("should handle roughly PI", () => {
   expect(p`3.1415 < < 3.1416`(Math.PI)).toBe(true);
   expect(p`3.1415 < < 3.1416`(3.1417)).toBe(false);
 });
+
+it("should notNil", () => {
+  const notNil = p`!(null | undefined)`;
+
+  expect(notNil("something")).toBe(true);
+  expect(notNil(false)).toBe(true);
+  expect(notNil(0)).toBe(true);
+  expect(notNil(null)).toBe(false);
+  expect(notNil(undefined)).toBe(false);
+});

--- a/index.test.js
+++ b/index.test.js
@@ -254,8 +254,8 @@ it("should handle emptys", () => {
 });
 
 it("should handle a user credentials object", () => {
-  const isOnlyLowerCase = p`String && !Nc && !Uc`;
-  const hasExtendedChars = p`String && Xc`;
+  const isOnlyLowerCase = p`String & !Nc & !Uc`;
+  const hasExtendedChars = p`String & Xc`;
 
   const isValidUser = p`{
     username: ${isOnlyLowerCase} && {length: 5 < < 9 },


### PR DESCRIPTION
This adds the shorter logical operators `&` and `|`
Updates some new examples and tests.
