### PR TITLE
Fixed an urgent precidence issue

### DIFF
--- a/packages/pdsl/grammar.js
+++ b/packages/pdsl/grammar.js
@@ -559,7 +559,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    prec: 100,
+    prec: 50,
     runtime: arrTypeMatch,
     toString() {
       return "Array<";
@@ -569,7 +569,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    prec: 100,
+    prec: 50,
     runtime: strLen,
     toString() {
       return "string[";
@@ -579,7 +579,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    prec: 100,
+    prec: 50,
     runtime: arrLen,
     toString() {
       return "array[";

--- a/packages/pdsl/helpers.js
+++ b/packages/pdsl/helpers.js
@@ -137,6 +137,8 @@ const arrArgMatch = (...tests) => {
 const arrTypeMatch = test => {
   const predicate = val(test);
   function matchFn(arr) {
+    if (!Array.isArray(arr)) return false;
+
     let matches = true;
     for (let i = 0; i < arr.length; i++) {
       matches = matches && predicate(arr[i]);

--- a/packages/pdsl/index.test.js
+++ b/packages/pdsl/index.test.js
@@ -586,6 +586,11 @@ it("should match Array<type> syntax", () => {
   expect(p`{property: Array<number>}`({ property: [1] })).toBe(true);
   expect(p`{property: Array<>6>}`({ property: [7, 8, 9] })).toBe(true);
   expect(p`{property: Array<>6>}`({ property: [1, 8, 9] })).toBe(false);
+  expect(p`Array<{name}>`([{ name: "Rudi" }])).toBe(true);
+  expect(p`Array<{name}>`([{ name: undefined }])).toBe(false);
+  expect(p`Array<{name}>`({ name: undefined })).toBe(false);
+  expect(p`Array<{name}> & {length:4, ...}`([{ name: "Rudi" }])).toBe(false);
+  expect(p`Array<{name}> & {length:1, ...}`([{ name: "Rudi" }])).toBe(true);
 });
 
 it("should support string length syntax", () => {
@@ -605,8 +610,12 @@ it("should support string length syntax", () => {
 it("should support array length syntax", () => {
   expect(p`array[4]`([1])).toBe(false);
   expect(p`array[4]`([1, 2, 3, 4])).toBe(true);
-  expect(p`array[4]`([1, 2, 3, 4, 5])).toBe(false);
+  expect(p`Array<number> & array[5]`([1, 2, 3, 4, 5])).toBe(true);
   expect(p`array[>4]`([1, 2, 3, 4, 5])).toBe(true);
+  expect(p`array[5] & Array<number> & [_,_,3, ...]`([1, 2, 3, 4, 5])).toBe(
+    true
+  );
+  expect(p`array[5] & Array<number> & [_,*,3]`([1, 2, 3, 4, 5])).toBe(false);
 });
 
 it("should parse logic in numeric value calulations", () => {


### PR DESCRIPTION
Discovered that a precedence issue was breaking functionality around the new syntax:

Stuff like this was failing

```js
p`array[5] & Array<number>`([1,2,3,4,5]);// false?
```