### PR TITLE
Added context to PDSL

### DIFF
--- a/packages/babel-plugin-pdsl/src/literals.js
+++ b/packages/babel-plugin-pdsl/src/literals.js
@@ -2,7 +2,7 @@ const t = require("@babel/types");
 const { types } = require("pdsl/grammar");
 
 function booleanLiteral(pdslNode) {
-  return t.booleanLiteral(pdslNode.token);
+  return t.booleanLiteral(pdslNode.runtime());
 }
 
 function predicateLiteral(pdslNode) {
@@ -10,7 +10,7 @@ function predicateLiteral(pdslNode) {
     case "Email":
       return t.callExpression(
         t.memberExpression(t.identifier("helpers"), t.identifier("regx")),
-        [t.identifier("Email")]
+        [t.memberExpression(t.identifier("helpers"), t.identifier("Email"))]
       );
     case "{}":
       return t.callExpression(
@@ -103,18 +103,18 @@ function predicateLiteral(pdslNode) {
 }
 
 function symbolLiteral(pdslNode) {
-  const { token } = pdslNode;
-  return t.stringLiteral(token);
+  const { runtime } = pdslNode;
+  return t.stringLiteral(runtime());
 }
 
 function numericLiteral(pdslNode) {
-  const { token } = pdslNode;
-  return t.numericLiteral(token);
+  const { runtime } = pdslNode;
+  return t.numericLiteral(runtime());
 }
 
 function stringLiteral(pdslNode) {
-  const { token } = pdslNode;
-  return t.stringLiteral(token);
+  const { runtime } = pdslNode;
+  return t.stringLiteral(runtime());
 }
 
 // return the relevant babel node for the given pdslNode literal

--- a/packages/babel-plugin-pdsl/src/literals.test.js
+++ b/packages/babel-plugin-pdsl/src/literals.test.js
@@ -10,28 +10,36 @@ const generate = require("@babel/generator").default;
 
 describe("numericLiteral", () => {
   test("3.1415", () => {
-    expect(generate(numericLiteral({ token: 3.1415 })).code).toBe("3.1415");
+    expect(generate(numericLiteral({ runtime: () => 3.1415 })).code).toBe(
+      "3.1415"
+    );
   });
 });
 describe("symbolLiteral", () => {
   test("foo", () => {
-    expect(generate(symbolLiteral({ token: "foo" })).code).toBe('"foo"');
+    expect(generate(symbolLiteral({ runtime: () => "foo" })).code).toBe(
+      '"foo"'
+    );
   });
 });
 
 describe("stringLiteral", () => {
   test("'foo'", () => {
-    expect(generate(stringLiteral({ token: "foo" })).code).toBe('"foo"');
+    expect(generate(stringLiteral({ runtime: () => "foo" })).code).toBe(
+      '"foo"'
+    );
   });
 });
 
 describe("booleanLiteral", () => {
   test("true", () => {
-    expect(generate(booleanLiteral({ token: true })).code).toBe("true");
+    expect(generate(booleanLiteral({ runtime: () => true })).code).toBe("true");
   });
 
   test("false", () => {
-    expect(generate(booleanLiteral({ token: false })).code).toBe("false");
+    expect(generate(booleanLiteral({ runtime: () => false })).code).toBe(
+      "false"
+    );
   });
 });
 
@@ -40,7 +48,7 @@ describe("predicateLiteral", () => {
     {
       name: "Email",
       input: tokens.EMAIL_REGX,
-      expected: "helpers.regx(Email)"
+      expected: "helpers.regx(helpers.Email)"
     },
     {
       name: "{}",

--- a/packages/babel-plugin-pdsl/src/runtime.js
+++ b/packages/babel-plugin-pdsl/src/runtime.js
@@ -6,7 +6,7 @@ const t = require("@babel/types");
 // pdslNode.runtime property
 function runtimeCreator(pdslNode) {
   return (...babelNodes) => {
-    const identifier = pdslNode.runtime.name;
+    const identifier = pdslNode.runtime().name;
     return t.callExpression(
       t.memberExpression(
         t.identifier("helpers"),

--- a/packages/babel-plugin-pdsl/test/fixtures/pdsl/code.js.txt
+++ b/packages/babel-plugin-pdsl/test/fixtures/pdsl/code.js.txt
@@ -8,3 +8,4 @@ assert.strictEqual(p`{name:${a => a.length > 10}}`({name:"12345678901"}), true);
 assert.strictEqual(p`_`(1), true);
 assert.strictEqual(p`_`(null), false);
 assert.strictEqual(p`Array<number> & array[5]`([1, 2, 3, 4, 5]),true);
+assert.strictEqual(p`Email`("email@example.com"),true);

--- a/packages/babel-plugin-pdsl/test/fixtures/pdsl/output.js.txt
+++ b/packages/babel-plugin-pdsl/test/fixtures/pdsl/output.js.txt
@@ -13,3 +13,4 @@ assert.strictEqual(helpers.val(helpers.obj(helpers.entry("name", helpers.pred(a 
 assert.strictEqual(helpers.val(helpers.extant)(1), true);
 assert.strictEqual(helpers.val(helpers.extant)(null), false);
 assert.strictEqual(helpers.val(helpers.and(helpers.arrTypeMatch(helpers.prim(Number)), helpers.arrLen(5)))([1, 2, 3, 4, 5]), true);
+assert.strictEqual(helpers.val(helpers.regx(helpers.Email))("email@example.com"), true);

--- a/packages/pdsl/grammar.js
+++ b/packages/pdsl/grammar.js
@@ -1,3 +1,4 @@
+const { getRawHelpers } = require("./helpers");
 const {
   and,
   btw,
@@ -28,7 +29,7 @@ const {
   strLen,
   arrLen,
   wildcard
-} = require("./helpers");
+} = getRawHelpers();
 
 // In order of global greedy token parsing
 const tokens = {
@@ -111,196 +112,224 @@ const grammar = {
   // LITERALS
   [tokens.TRUE]: token => ({
     type: types.BooleanLiteral,
-    token: true,
+    token,
+    runtime: () => true,
     toString() {
       return token;
     }
   }),
   [tokens.FALSE]: token => ({
     type: types.BooleanLiteral,
-    token: false,
+    token,
+    runtime: () => false,
     toString() {
       return token;
     }
   }),
-  [tokens.EMAIL_REGX]: () => ({
+  [tokens.EMAIL_REGX]: token => ({
     type: types.PredicateLiteral,
-    token: regx(Email),
+    token,
+    runtime: ctx => regx(ctx)(Email),
     toString() {
       return "Email";
     }
   }),
-  [tokens.EXTENDED_CHARS_REGX]: () => ({
+  [tokens.EXTENDED_CHARS_REGX]: token => ({
     type: types.PredicateLiteral,
-    token: regx(Xc),
+    token,
+    runtime: ctx => regx(ctx)(Xc),
     toString() {
       return "Xc";
     }
   }),
-  [tokens.NUM_CHARS_REGX]: () => ({
+  [tokens.NUM_CHARS_REGX]: token => ({
     type: types.PredicateLiteral,
-    token: regx(Nc),
+    token,
+    runtime: ctx => regx(ctx)(Nc),
     toString() {
       return "Nc";
     }
   }),
-  [tokens.LOW_CHARS_REGX]: () => ({
+  [tokens.LOW_CHARS_REGX]: token => ({
     type: types.PredicateLiteral,
-    token: regx(Lc),
+    token,
+    runtime: ctx => regx(ctx)(Lc),
     toString() {
       return "Lc";
     }
   }),
-  [tokens.UP_CHARS_REGX]: () => ({
+  [tokens.UP_CHARS_REGX]: token => ({
     type: types.PredicateLiteral,
-    token: regx(Uc),
+    token,
+    runtime: ctx => regx(ctx)(Uc),
     toString() {
       return "Uc";
     }
   }),
-  [tokens.LOW_UP_CHARS_REGX]: () => ({
+  [tokens.LOW_UP_CHARS_REGX]: token => ({
     type: types.PredicateLiteral,
-    token: regx(LUc),
+    token,
+    runtime: ctx => regx(ctx)(LUc),
     toString() {
       return "LUc";
     }
   }),
-  [tokens.EMPTY_OBJ]: () => ({
+  [tokens.EMPTY_OBJ]: token => ({
     type: types.PredicateLiteral,
-    token: deep({}),
+    token,
+    runtime: ctx => deep(ctx)({}),
     toString() {
       return "{}";
     }
   }),
-  [tokens.EMPTY_ARRAY]: () => ({
+  [tokens.EMPTY_ARRAY]: token => ({
     type: types.PredicateLiteral,
-    token: deep([]),
+    token,
+    runtime: ctx => deep(ctx)([]),
     toString() {
       return "[]";
     }
   }),
-  [tokens.EMPTY_STRING_DOUBLE]: () => ({
+  [tokens.EMPTY_STRING_DOUBLE]: token => ({
     type: types.PredicateLiteral,
-    token: deep(""),
+    token,
+    runtime: ctx => deep(ctx)(""),
     toString() {
       return `""`;
     }
   }),
-  [tokens.EMPTY_STRING_SINGLE]: () => ({
+  [tokens.EMPTY_STRING_SINGLE]: token => ({
     type: types.PredicateLiteral,
-    token: deep(""),
+    token,
+    runtime: ctx => deep(ctx)(""),
     toString() {
       return `""`;
     }
   }),
   [tokens.PRIM_NUMBER]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Number),
+    token,
+    runtime: ctx => prim(ctx)(Number),
     toString() {
       return "Number";
     }
   }),
   [tokens.PRIM_OBJECT]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Object),
+    token,
+    runtime: ctx => prim(ctx)(Object),
     toString() {
       return "Object";
     }
   }),
   [tokens.PRIM_ARRAY]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Array),
+    token,
+    runtime: ctx => prim(ctx)(Array),
     toString() {
       return "Array";
     }
   }),
-  [tokens.NULL]: () => ({
+  [tokens.NULL]: token => ({
     type: types.PredicateLiteral,
-    token: val(null),
+    token,
+    runtime: ctx => val(ctx)(null),
     toString() {
       return "null";
     }
   }),
-  [tokens.UNDEFINED]: () => ({
+  [tokens.UNDEFINED]: token => ({
     type: types.PredicateLiteral,
-    token: val(undefined),
+    token,
+    runtime: ctx => val(ctx)(undefined),
     toString() {
       return "undefined";
     }
   }),
   [tokens.PRIM_NUMBER_VAL]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Number),
+    token,
+    runtime: ctx => prim(ctx)(Number),
     toString() {
       return "number";
     }
   }),
   [tokens.PRIM_BOOLEAN_VAL]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Boolean),
+    token,
+    runtime: ctx => prim(ctx)(Boolean),
     toString() {
       return "boolean";
     }
   }),
   [tokens.PRIM_SYMBOL_VAL]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Symbol),
+    token,
+    runtime: ctx => prim(ctx)(Symbol),
     toString() {
       return "symbol";
     }
   }),
   [tokens.PRIM_STRING_VAL]: token => ({
     type: types.PredicateLiteral,
-    token: prim(String),
+    token,
+    runtime: ctx => prim(ctx)(String),
     toString() {
       return "string";
     }
   }),
   [tokens.PRIM_ARRAY_VAL]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Array),
+    token,
+    runtime: /* istanbul ignore next */ ctx => prim(ctx)(Array),
     toString() {
       return "array";
     }
   }),
   [tokens.PRIM_BOOLEAN]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Boolean),
+    token,
+    runtime: ctx => prim(ctx)(Boolean),
     toString() {
       return "Boolean";
     }
   }),
   [tokens.PRIM_STRING]: token => ({
     type: types.PredicateLiteral,
-    token: prim(String),
+    token,
+    runtime: ctx => prim(ctx)(String),
     toString() {
       return "String";
     }
   }),
   [tokens.PRIM_SYMBOL]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Symbol),
+    token,
+    runtime: ctx => prim(ctx)(Symbol),
     toString() {
       return "Symbol";
     }
   }),
   [tokens.PRIM_FUNCTION]: token => ({
     type: types.PredicateLiteral,
-    token: prim(Function),
+    token,
+    runtime: ctx => prim(ctx)(Function),
     toString() {
       return "Function";
     }
   }),
   [tokens.EXTANT_PREDICATE]: token => ({
     type: types.PredicateLiteral,
-    token: extant,
+    token,
+    runtime: ctx => extant(ctx),
     toString() {
       return "_";
     }
   }),
   [tokens.WILDCARD_PREDICATE]: token => ({
     type: types.PredicateLiteral,
-    token: wildcard,
+    token,
+    runtime: ctx => wildcard(ctx),
     toString() {
       return "*";
     }
@@ -308,7 +337,8 @@ const grammar = {
   [tokens.TRUTHY]: token => {
     return {
       type: types.PredicateLiteral,
-      token: truthy,
+      token,
+      runtime: ctx => truthy(ctx),
       toString() {
         return "!!";
       }
@@ -317,7 +347,8 @@ const grammar = {
   [tokens.FALSY_KEYWORD]: token => {
     return {
       type: types.PredicateLiteral,
-      token: falsey,
+      token,
+      runtime: ctx => falsey(ctx),
       toString() {
         return "!";
       }
@@ -327,6 +358,7 @@ const grammar = {
   [tokens.SYMBOL]: token => ({
     type: types.SymbolLiteral,
     token,
+    runtime: () => token, // token will be a string as in "name" so ctx makes no sense
     toString() {
       return token;
     }
@@ -334,22 +366,27 @@ const grammar = {
   [tokens.REST_SYMBOL]: token => ({
     type: types.SymbolLiteral,
     token,
+    runtime: () => token,
     toString() {
       return token;
     }
   }),
   [tokens.NUMBER]: token => ({
     type: types.NumericLiteral,
-    token: Number(token),
+    token,
+    runtime: () => Number(token),
     toString() {
       return token;
     }
   }),
   [tokens.STRING_DOUBLE]: token => {
     const t = token.match(/\"(.*)\"/);
+    /* istanbul ignore next because __deafult never matches in tests */
+    const val = t ? t[1] : "__default";
     return {
       type: types.StringLiteral,
-      token: t ? t[1] : "__default",
+      token: val,
+      runtime: () => val,
       toString() {
         return token;
       }
@@ -357,9 +394,12 @@ const grammar = {
   },
   [tokens.STRING_SINGLE]: token => {
     const t = token.match(/\'(.*)\'/);
+    /* istanbul ignore next because __deafult never matches in tests */
+    const val = t ? t[1] : "__default";
     return {
       type: types.StringLiteral,
-      token: t ? t[1] : "__default",
+      token: val,
+      runtime: () => val,
       toString() {
         return token;
       }
@@ -367,9 +407,12 @@ const grammar = {
   },
   [tokens.PREDICATE_LOOKUP]: token => {
     const t = token.match(/@{LINK:(\d+)}/);
+    /* istanbul ignore next because __deafult never matches in tests */
+    const val = t ? t[1] : "__default";
     return {
       type: types.PredicateLookup,
-      token: t ? t[1] : "__default",
+      token: val,
+      runtime: /* istanbul ignore next as not used */ () => val,
       toString() {
         return token;
       }
@@ -382,7 +425,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    runtime: not,
+    runtime: ctx => not(ctx),
     toString() {
       return token + this.arity;
     },
@@ -392,7 +435,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 2,
-    runtime: and,
+    runtime: ctx => and(ctx),
     prec: 60,
     toString() {
       return token;
@@ -402,7 +445,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 2,
-    runtime: and,
+    runtime: ctx => and(ctx),
     prec: 60,
     toString() {
       return token;
@@ -413,7 +456,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 2,
-    runtime: or,
+    runtime: ctx => or(ctx),
     prec: 60,
     toString() {
       return token;
@@ -423,7 +466,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 2,
-    runtime: or,
+    runtime: ctx => or(ctx),
     prec: 60,
     toString() {
       return token;
@@ -433,7 +476,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 2,
-    runtime: btw,
+    runtime: ctx => btw(ctx),
     prec: 50,
     toString() {
       return token;
@@ -443,7 +486,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 2,
-    runtime: btwe,
+    runtime: ctx => btwe(ctx),
     prec: 50,
     toString() {
       return token;
@@ -453,7 +496,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    runtime: gte,
+    runtime: ctx => gte(ctx),
     prec: 50,
     toString() {
       return token;
@@ -463,7 +506,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    runtime: lte,
+    runtime: ctx => lte(ctx),
     prec: 50,
     toString() {
       return token;
@@ -473,7 +516,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    runtime: gt,
+    runtime: ctx => gt(ctx),
     prec: 50,
     toString() {
       return token;
@@ -483,7 +526,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 1,
-    runtime: lt,
+    runtime: ctx => lt(ctx),
     prec: 50,
     toString() {
       return token;
@@ -495,7 +538,7 @@ const grammar = {
     type: types.Operator,
     token,
     arity: 2,
-    runtime: entry,
+    runtime: ctx => entry(ctx),
     prec: 100,
     toString() {
       return token;
@@ -506,7 +549,7 @@ const grammar = {
     type: types.VariableArityOperator,
     token,
     arity: 0,
-    runtime: obj,
+    runtime: ctx => obj(ctx),
     prec: 100,
     toString() {
       return token + this.arity;
@@ -526,7 +569,7 @@ const grammar = {
     type: types.VariableArityOperator,
     token,
     arity: 0,
-    runtime: arrArgMatch,
+    runtime: ctx => arrArgMatch(ctx),
     prec: 100,
     toString() {
       return token + this.arity;
@@ -569,7 +612,7 @@ const grammar = {
     token,
     arity: 1,
     prec: 50,
-    runtime: arrTypeMatch,
+    runtime: ctx => arrTypeMatch(ctx),
     toString() {
       return "Array<";
     }
@@ -589,7 +632,7 @@ const grammar = {
     token,
     arity: 1,
     prec: 50,
-    runtime: arrLen,
+    runtime: ctx => arrLen(ctx),
     toString() {
       return "array[";
     }

--- a/packages/pdsl/helpers.js
+++ b/packages/pdsl/helpers.js
@@ -6,6 +6,9 @@ const {
   isRegEx
 } = require("./utils");
 
+// NOTE:  All return functions must have names becuase
+//        they are used for the babel plugin
+
 /**
  * <h3>Between bounds</h3>
  * Return a function that checks to see if it's input is between two numbers not including the numbers.
@@ -14,10 +17,12 @@ const {
  * @param {number} b The higher number
  * @return {function} A function of the form number => boolean
  */
-const btw = () => (a, b) =>
-  function btwFn(n) {
-    const [min, max] = a < b ? [a, b] : [b, a];
-    return n > min && n < max;
+const btw = () =>
+  function btw(a, b) {
+    return function btwFn(n) {
+      const [min, max] = a < b ? [a, b] : [b, a];
+      return n > min && n < max;
+    };
   };
 
 /**
@@ -28,10 +33,12 @@ const btw = () => (a, b) =>
  * @param {number} b The higher number
  * @return {function} A function of the form number => boolean
  */
-const btwe = () => (a, b) =>
-  function btweFn(n) {
-    const [min, max] = a < b ? [a, b] : [b, a];
-    return n >= min && n <= max;
+const btwe = () =>
+  function btwe(a, b) {
+    return function btweFn(n) {
+      const [min, max] = a < b ? [a, b] : [b, a];
+      return n >= min && n <= max;
+    };
   };
 
 /**
@@ -41,9 +48,11 @@ const btwe = () => (a, b) =>
  * @param {number} a The number to check against.
  * @return {function} A function of the form number => boolean
  */
-const lt = () => a =>
-  function ltFn(n) {
-    return n < a;
+const lt = () =>
+  function lt(a) {
+    return function ltFn(n) {
+      return n < a;
+    };
   };
 
 /**
@@ -53,9 +62,11 @@ const lt = () => a =>
  * @param {number} a The number to check against.
  * @return {function} A function of the form number => boolean
  */
-const lte = () => a =>
-  function lteFn(n) {
-    return n <= a;
+const lte = () =>
+  function lte(a) {
+    return function lteFn(n) {
+      return n <= a;
+    };
   };
 
 /**
@@ -65,11 +76,12 @@ const lte = () => a =>
  * @param {number} a The number to check against.
  * @return {function} A function of the form number => boolean
  */
-const gt = () => a =>
-  function gtFn(n) {
-    return n > a;
+const gt = () =>
+  function gt(a) {
+    return function gtFn(n) {
+      return n > a;
+    };
   };
-
 /**
  * <h3>Greater than or equal to</h3>
  * Return a function that checks to see if it's input is greater than or equal to the given number.
@@ -77,9 +89,11 @@ const gt = () => a =>
  * @param {number} a The number to check against.
  * @return {function} A function of the form number => boolean
  */
-const gte = () => a =>
-  function gteFn(n) {
-    return n >= a;
+const gte = () =>
+  function gte(a) {
+    return function gteFn(n) {
+      return n >= a;
+    };
   };
 
 /**
@@ -102,20 +116,21 @@ const gte = () => a =>
  * @param {...function|*} tests Either values, `['...', predicate]` or predicate functions used to test the contents of the array.
  * @return {function} A function of the form <code>{array => boolean}</code>
  */
-const arrArgMatch = ctx => (...tests) => {
-  function matchFn(arr) {
-    const hasWildcard = tests.slice(-1)[0] === "...";
-    let matches = hasWildcard || arr.length === tests.length;
-    for (let i = 0; i < tests.length; i++) {
-      const testVal = tests[i];
-      const predicate = testVal === "..." ? wildcard(ctx) : val(ctx)(testVal);
-      const pass = predicate(arr[i]);
-      matches = matches && pass;
+const arrArgMatch = ctx =>
+  function arrArgMatch(...tests) {
+    function matchFn(arr) {
+      const hasWildcard = tests.slice(-1)[0] === "...";
+      let matches = hasWildcard || arr.length === tests.length;
+      for (let i = 0; i < tests.length; i++) {
+        const testVal = tests[i];
+        const predicate = testVal === "..." ? wildcard(ctx) : val(ctx)(testVal);
+        const pass = predicate(arr[i]);
+        matches = matches && pass;
+      }
+      return matches;
     }
-    return matches;
-  }
-  return matchFn;
-};
+    return matchFn;
+  };
 
 /**
  * <h3>Array type match</h3>
@@ -134,19 +149,20 @@ const arrArgMatch = ctx => (...tests) => {
  * @param {function|*} test predicate function used to test the contents of the array.
  * @return {function} A function of the form <code>{array => boolean}</code>
  */
-const arrTypeMatch = ctx => test => {
-  const predicate = val(ctx)(test);
-  function matchFn(arr) {
-    if (!Array.isArray(arr)) return false;
+const arrTypeMatch = ctx =>
+  function arrTypeMatch(test) {
+    const predicate = val(ctx)(test);
+    function matchFn(arr) {
+      if (!Array.isArray(arr)) return false;
 
-    let matches = true;
-    for (let i = 0; i < arr.length; i++) {
-      matches = matches && predicate(arr[i]);
+      let matches = true;
+      for (let i = 0; i < arr.length; i++) {
+        matches = matches && predicate(arr[i]);
+      }
+      return matches;
     }
-    return matches;
-  }
-  return matchFn;
-};
+    return matchFn;
+  };
 
 /**
  * <h3>Array holds</h3>
@@ -160,31 +176,33 @@ const arrTypeMatch = ctx => test => {
  * @param {...function|*} args Either values or predicate functions used to test the contents of the array.
  * @return {function} A function of the form <code>{array => boolean}</code>
  */
-const holds = ctx => (...args) =>
-  function holdsFn(n) {
-    let i, j;
-    let fns = [];
-    let success = [];
+const holds = ctx =>
+  function holds(...args) {
+    return function holdsFn(n) {
+      let i, j;
+      let fns = [];
+      let success = [];
 
-    // prepare args as an array of predicate fns and an array to keep track of success
-    for (i = 0; i < args.length; i++) {
-      const arg = args[i];
-      fns.push(val(ctx)(arg));
-      success.push(false);
-    }
+      // prepare args as an array of predicate fns and an array to keep track of success
+      for (i = 0; i < args.length; i++) {
+        const arg = args[i];
+        fns.push(val(ctx)(arg));
+        success.push(false);
+      }
 
-    // loop through array only once
-    for (i = 0; i < n.length; i++) {
-      const item = n[i];
-      for (j = 0; j < fns.length; j++) {
-        if (!success[j]) {
-          const fn = fns[j];
-          success[j] = success[j] || fn(item);
+      // loop through array only once
+      for (i = 0; i < n.length; i++) {
+        const item = n[i];
+        for (j = 0; j < fns.length; j++) {
+          if (!success[j]) {
+            const fn = fns[j];
+            success[j] = success[j] || fn(item);
+          }
         }
       }
-    }
 
-    return success.reduce((a, b) => a && b);
+      return success.reduce((a, b) => a && b);
+    };
   };
 
 /**
@@ -195,10 +213,12 @@ const holds = ctx => (...args) =>
  * @param {function} right The second predicate
  * @return {function} A function of the form <code>{any => boolean}</code>
  */
-const or = ctx => (left, right) =>
-  function orFn(a) {
-    const valCtx = val(ctx);
-    return valCtx(left)(a) || valCtx(right)(a);
+const or = ctx =>
+  function or(left, right) {
+    return function orFn(a) {
+      const valCtx = val(ctx);
+      return valCtx(left)(a) || valCtx(right)(a);
+    };
   };
 
 /**
@@ -209,10 +229,12 @@ const or = ctx => (left, right) =>
  * @param {function} right The second predicate
  * @return {function} A function of the form <code>{any => boolean}</code>
  */
-const and = ctx => (left, right) =>
-  function andFn(a) {
-    const valCtx = val(ctx);
-    return valCtx(left)(a) && valCtx(right)(a);
+const and = ctx =>
+  function and(left, right) {
+    return function andFn(a) {
+      const valCtx = val(ctx);
+      return valCtx(left)(a) && valCtx(right)(a);
+    };
   };
 
 /**
@@ -222,12 +244,17 @@ const and = ctx => (left, right) =>
  * @param {function} input The input predicate
  * @return {function} A function of the form <code>{any => boolean}</code>
  */
-const not = ctx => input =>
-  function notFn(a) {
-    return !val(ctx)(input)(a);
+const not = ctx =>
+  function not(input) {
+    return function notFn(a) {
+      return !val(ctx)(input)(a);
+    };
   };
 
-const extant = () => a => a !== null && a !== undefined;
+const extant = () =>
+  function extant(a) {
+    return a !== null && a !== undefined;
+  };
 
 /**
  * <h3>Truthy</h3>
@@ -236,7 +263,10 @@ const extant = () => a => a !== null && a !== undefined;
  * @param {function} input The input value
  * @return {boolean} Boolean value indicating if the input is truthy
  */
-const truthy = () => a => !!a;
+const truthy = () =>
+  function truthy(a) {
+    return !!a;
+  };
 
 /**
  * <h3>Falsey</h3>
@@ -245,38 +275,45 @@ const truthy = () => a => !!a;
  * @param {function} input The input value
  * @return {boolean} Boolean value indicating if the input is falsey
  */
-const falsey = () => a => !a;
+const falsey = () =>
+  function falsey(a) {
+    return !a;
+  };
 
-const obj = ctx => (...entriesWithRest) =>
-  function objFn(a) {
-    const isExtant = extant(ctx);
-    let hasRest = false;
-    let entriesMatch = true;
-    let entryCount = 0;
+const obj = ctx =>
+  function obj(...entriesWithRest) {
+    return function objFn(a) {
+      const isExtant = extant(ctx);
+      let hasRest = false;
+      let entriesMatch = true;
+      let entryCount = 0;
 
-    // For loop is faster
-    for (let i = 0; i < entriesWithRest.length; i++) {
-      const entry = entriesWithRest[i];
+      // For loop is faster
+      for (let i = 0; i < entriesWithRest.length; i++) {
+        const entry = entriesWithRest[i];
 
-      // Ignore rest and note we have one
-      if (entry === "...") {
-        hasRest = hasRest || true;
-        continue;
+        // Ignore rest and note we have one
+        if (entry === "...") {
+          hasRest = hasRest || true;
+          continue;
+        }
+
+        // Extract key and predicate from the entry and run the predicate against the value
+        const [key, predicate] = Array.isArray(entry)
+          ? entry
+          : [entry, isExtant];
+        entriesMatch = entriesMatch && isExtant(a) && predicate(a[key]);
+
+        // We just logged an entry track it
+        entryCount++;
       }
 
-      // Extract key and predicate from the entry and run the predicate against the value
-      const [key, predicate] = Array.isArray(entry) ? entry : [entry, isExtant];
-      entriesMatch = entriesMatch && isExtant(a) && predicate(a[key]);
+      // If there was a rest arg we don't need to check length
+      if (hasRest) return entriesMatch;
 
-      // We just logged an entry track it
-      entryCount++;
-    }
-
-    // If there was a rest arg we don't need to check length
-    if (hasRest) return entriesMatch;
-
-    // Check entry length
-    return entriesMatch && Object.keys(a).length === entryCount;
+      // Check entry length
+      return entriesMatch && Object.keys(a).length === entryCount;
+    };
   };
 
 /**
@@ -300,10 +337,11 @@ const val = () => value =>
  * @param {function} value The input value
  * @return {function} A function of the form <code>{any => boolean}</code>
  */
-const deep = () => value => {
-  const st = JSON.stringify(value);
-  return a => st === JSON.stringify(a);
-};
+const deep = () =>
+  function deep(value) {
+    const st = JSON.stringify(value);
+    return a => st === JSON.stringify(a);
+  };
 
 /**
  * <h3>Regular Expression predicate</h3>
@@ -312,10 +350,11 @@ const deep = () => value => {
  * @param {RegExp} rx The input value
  * @return {function} A function of the form <code>{any => boolean}</code>
  */
-const regx = ctx => rx => {
-  const rgx = typeof rx === "function" ? rx(ctx) : rx;
-  return rgx.test.bind(rgx);
-};
+const regx = ctx =>
+  function regx(rx) {
+    const rgx = typeof rx === "function" ? rx(ctx) : rx;
+    return rgx.test.bind(rgx);
+  };
 
 /**
  * <h3>Primative predicate</h3>
@@ -329,11 +368,12 @@ const regx = ctx => rx => {
  * @param {object} primative The input primative one of Array, Boolean, Number, Symbol, BigInt, String, Function, Object
  * @return {function} A function of the form <code>{any => boolean}</code>
  */
-const prim = () => primative => {
-  if (primative.name === "Array") return a => Array.isArray(a);
+const prim = () =>
+  function prim(primative) {
+    if (primative.name === "Array") return a => Array.isArray(a);
 
-  return a => typeof a === primative.name.toLowerCase();
-};
+    return a => typeof a === primative.name.toLowerCase();
+  };
 
 function createExpressionParser(ctx, expression) {
   if (isFunction(expression)) {
@@ -352,26 +392,35 @@ function createExpressionParser(ctx, expression) {
  * @param {*} input Anything parsable
  * @return {function} A function of the form <code>{any => boolean}</code>
  */
-const pred = ctx => input => {
-  const expParser = createExpressionParser(ctx, input);
-  return expParser(input);
-};
-
-const strLen = ctx => input =>
-  function strLenFn(a) {
-    return typeof a === "string" && val(ctx)(input)(a.length);
+const pred = ctx =>
+  function pred(input) {
+    const expParser = createExpressionParser(ctx, input);
+    return expParser(input);
   };
 
-const arrLen = ctx => input =>
-  function arrLenFn(a) {
-    return Array.isArray(a) && val(ctx)(input)(a.length);
+const strLen = ctx =>
+  function strLen(input) {
+    return function strLenFn(a) {
+      return typeof a === "string" && val(ctx)(input)(a.length);
+    };
   };
 
-const wildcard = () => () => true;
+const arrLen = ctx =>
+  function arrLen(input) {
+    return function arrLenFn(a) {
+      return Array.isArray(a) && val(ctx)(input)(a.length);
+    };
+  };
 
-const entry = ctx => (name, predicate) => {
-  return [name, val(ctx)(predicate)];
-};
+const wildcard = () =>
+  function wilcard() {
+    return true;
+  };
+
+const entry = ctx =>
+  function entry(name, predicate) {
+    return [name, val(ctx)(predicate)];
+  };
 
 const Email = () => /^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]+)$/;
 const Xc = () => /(?=.*[^a-zA-Z0-9\s]).*/;

--- a/packages/pdsl/helpers.test.js
+++ b/packages/pdsl/helpers.test.js
@@ -20,11 +20,18 @@ const {
 
 it("should obj", () => {
   expect(
-    obj(["name", a => a === "foo"], ["age", a => a === 41])({
+    obj(
+      ["name", a => a === "foo"],
+      ["age", a => a === 41]
+    )({
       name: "foo",
       age: 41
     })
   ).toBe(true);
+});
+
+it("should check email", () => {
+  expect(val(regx(Email))("contact@rudiyardley.com")).toBe(true);
 });
 
 it("should extant", () => {

--- a/packages/pdsl/index.js
+++ b/packages/pdsl/index.js
@@ -1,8 +1,9 @@
 const { parser } = require("./parser");
 const { lexer } = require("./lexer");
 const { generator } = require("./generator");
-const { pred } = require("./helpers");
+const { getRawHelpers } = require("./helpers");
 const { pretokenizer } = require("./pretokenizer");
+const { pred } = getRawHelpers();
 
 const flow = (...funcs) => input =>
   funcs.reduce((out, func) => func(out), input);
@@ -11,34 +12,31 @@ const debugAst = ast => ast.map(a => a.toString()).join(" ");
 
 const cleanup = a => a.filter(Boolean);
 
-const toAst = flow(
-  pretokenizer,
-  lexer,
-  parser,
-  cleanup
-);
+const toAst = flow(pretokenizer, lexer, parser, cleanup);
 
-function p(strings, ...expressions) {
-  return generator(toAst(strings), expressions.map(pred));
+const configP = ctx => (strings, ...expressions) => {
+  return generator(toAst(strings), expressions.map(pred(ctx)), ctx);
+};
+
+function config(ctx) {
+  return configP(ctx);
 }
 
+const defaultContext = {};
+
+const p = configP(defaultContext);
+
 function debugRpn(strings) {
-  return flow(
-    toAst,
-    debugAst
-  )(strings);
+  return flow(toAst, debugAst)(strings);
 }
 
 function debugTokens(strings) {
-  return flow(
-    pretokenizer,
-    lexer,
-    debugAst
-  )(strings);
+  return flow(pretokenizer, lexer, debugAst)(strings);
 }
 
 p.unsafe_rpn = debugRpn;
 p.unsafe_tokens = debugTokens;
+p.config = config;
 
 module.exports = p;
 module.exports.default = p;

--- a/packages/pdsl/index.test.js
+++ b/packages/pdsl/index.test.js
@@ -1,5 +1,6 @@
 const p = require("./index");
-const { Email, gt } = require("./helpers");
+const helpers = require("./helpers");
+const { Email, gt } = helpers();
 
 describe("value predicates", () => {
   it("should return strict equality with any value", () => {
@@ -347,6 +348,7 @@ it("should respect a wildcard on an object", () => {
 it("should handle greater than equals ", () => {
   expect(p`>=5`(6)).toBe(true);
   expect(p`>=5`(5)).toBe(true);
+  expect(p`<=5`(4)).toBe(true);
   expect(p`>=5`(4)).toBe(false);
   expect(p`{age:>=5}`({ age: 34 })).toBe(true);
 });
@@ -634,4 +636,9 @@ it("should handle nested properties starting with underscores", () => {
       action: { _typename: "Redirect" }
     })
   ).toBe(true);
+});
+
+it("should be able to pass a config object in", () => {
+  expect(p.config({})`>5`(6)).toBe(true);
+  expect(p.config({})`>5`(5)).toBe(false);
 });

--- a/packages/pdsl/lexer.js
+++ b/packages/pdsl/lexer.js
@@ -41,7 +41,7 @@ function disambiguateNotOperator(node, index, arr) {
     return node;
   }
 
-  return grammar[tokens.FALSY_KEYWORD]();
+  return grammar[tokens.FALSY_KEYWORD]("!");
 }
 
 function lexer(input) {


### PR DESCRIPTION
This PR adds the ability to provide context to helpers. This means we can provide configuration to PDSL and create different behaviour based on a global config.

The way it works is that helpers are stored as curried functions and the `helpers.js` exports functions provided a defaultContext of `{}`. To get a raw helper you can use the `getRawHelpers()` function exported from the helpers file. This means you can provide a context to the helper:

Eg.

```js
import {getRawHelpers} from 'pdsl/helpers';
const {gt:rawGt} = getRawHelpers();

const gt = rawGt({ someSpecialConf:true });
gt(6)(5); // false
```

You can now provide global configuration to pdsl using the config function property on the default object:

```js
import pdsl from 'pdsl';

const p = pdsl.config({someConfig:true});

p`{with: {some:{config:true}}}`({}); // false