### PR TITLE
Loose matching by default with strict matching syntax

### DIFF
--- a/packages/pdsl/context.js
+++ b/packages/pdsl/context.js
@@ -1,6 +1,9 @@
 const defaultConfig = { abortEarly: true };
 const { lookup } = require("./i18n");
 
+// TODO: Get this to compose state helper objects to
+//      handle the objet stack and exact matching depth analysis
+
 class Context {
   constructor(options = {}) {
     this.reset();
@@ -10,7 +13,8 @@ class Context {
   reset(options = {}) {
     this.errs = [];
     this.errStack = [];
-    this.objStack = [];
+    this.objStack = []; // store our nested object path keys
+    this.objExactStack = []; // store nested exact matching objects
     this.config = {};
     this.batch = [];
     this.isBatching = false;
@@ -56,15 +60,22 @@ class Context {
     return lookup(key);
   }
 
-  pushObjStack(key) {
+  pushObjStack(key, isExactMatching) {
+    this.objExactStack.push(isExactMatching);
     const out = this.objStack.push(key);
     return out;
   }
 
   popObjStack() {
+    this.objExactStack.pop();
     const key = this.objStack.pop();
     return key;
   }
+
+  getObjExactStack() {
+    return this.objExactStack;
+  }
+
   pushErrStack(key) {
     const out = this.errStack.push(key);
     return out;

--- a/packages/pdsl/grammar.js
+++ b/packages/pdsl/grammar.js
@@ -622,6 +622,7 @@ const grammar = {
     runtime: ctx => obj(ctx, true),
     runtimeIdentifier: "obj",
     prec: 100,
+    closingToken: "|}",
     toString() {
       return token + this.arity;
     }
@@ -642,6 +643,7 @@ const grammar = {
     runtime: ctx => obj(ctx),
     runtimeIdentifier: "obj",
     prec: 100,
+    closingToken: "}",
     toString() {
       return token + this.arity;
     }
@@ -662,6 +664,7 @@ const grammar = {
     runtime: ctx => arrIncl(ctx),
     runtimeIdentifier: "arrIncl",
     prec: 100,
+    closingToken: "]",
     toString() {
       return token + this.arity;
     }
@@ -674,6 +677,7 @@ const grammar = {
     runtime: ctx => arrArgMatch(ctx),
     runtimeIdentifier: "arrArgMatch",
     prec: 100,
+    closingToken: "]",
     toString() {
       return token + this.arity;
     }
@@ -771,9 +775,14 @@ function isVaradicFunctionClose(node) {
   return node.type === types.VariableArityOperatorClose;
 }
 
-function isVaradicFunction(node) {
+function isVaradicFunction(node, closingNode) {
   if (!node) return false;
-  return node.type === types.VariableArityOperator;
+
+  const isVaradicStart = node.type === types.VariableArityOperator;
+
+  if (!closingNode) return isVaradicStart;
+
+  return isVaradicStart && node.closingToken === closingNode.token;
 }
 
 function isBooleanable(node) {

--- a/packages/pdsl/grammar.js
+++ b/packages/pdsl/grammar.js
@@ -75,6 +75,8 @@ const tokens = {
   STRING_DOUBLE: `\\"[^\\"]*\\"`,
   STRING_SINGLE: `\\'[^\\']*\\'`,
   PREDICATE_LOOKUP: "@{LINK:(\\d+)}",
+  OBJ_EXACT: "\\{\\|",
+  OBJ_EXACT_CLOSE: "\\|\\}",
   NOT: "\\!",
   AND: "\\&\\&",
   AND_SHORT: "\\&",
@@ -608,6 +610,26 @@ const grammar = {
     runtime: ctx => entry(ctx),
     runtimeIdentifier: "entry",
     prec: 100,
+    toString() {
+      return token;
+    }
+  }),
+
+  [tokens.OBJ_EXACT]: token => ({
+    type: types.VariableArityOperator,
+    token,
+    arity: 0,
+    runtime: ctx => obj(ctx, true),
+    runtimeIdentifier: "obj",
+    prec: 100,
+    toString() {
+      return token + this.arity;
+    }
+  }),
+
+  [tokens.OBJ_EXACT_CLOSE]: token => ({
+    type: types.VariableArityOperatorClose,
+    token,
     toString() {
       return token;
     }

--- a/packages/pdsl/index.test.js
+++ b/packages/pdsl/index.test.js
@@ -163,6 +163,20 @@ it("should match exactly all the way down the object tree unless you use a rest"
   ).toBe(true);
 });
 
+it("should throw when mismatching strict object syntax", () => {
+  expect(() => {
+    p`{| name }`;
+  }).toThrow();
+
+  expect(() => {
+    p`{| name: [ "foo" |} `;
+  }).toThrow();
+
+  expect(() => {
+    p`{| name `;
+  }).toThrow();
+});
+
 it("should be able to use nested object property templates", () => {
   expect(
     p`{ meta: { remote }, ...}`({ type: "shared.foo", meta: { remote: true } })
@@ -326,7 +340,8 @@ it("should test the toString() calls for code coverage", () => {
     ... |
     Array< |
     string[ |
-    array[ |`
+    array[ |
+    [? |`
   ).toBe(
     [
       "[0 1 .. 4 ]",
@@ -367,7 +382,8 @@ it("should test the toString() calls for code coverage", () => {
       "...",
       "Array<",
       "string[",
-      "array["
+      "array[",
+      "[?0"
     ].join(" | ") + " |"
   );
 });

--- a/packages/pdsl/index.test.js
+++ b/packages/pdsl/index.test.js
@@ -91,16 +91,62 @@ it("should use the extant predicate as the default object checking behaviour", (
   expect(p`{ name }`({ name: null })).toBe(false);
 });
 
-it("should use exact matching", () => {
-  expect(p`{ name }`({ name: "Fred" })).toBe(true);
-  expect(p`{ name }`({ name: "Fred", age: 12 })).toBe(false);
+it("should be loose matching by default", () => {
+  expect(p`{ name }`({ name: "Fred", age: 12 })).toBe(true);
+  expect(p`{ name }`({ name: "Fred", age: 12 })).toBe(true);
   expect(p`{ name, age }`({ name: "Fred", age: 12 })).toBe(true);
 });
 
-it("should use a rest symbol to allow loose matching", () => {
-  expect(p`{ name }`({ name: "Fred", age: 12 })).toBe(false);
-  expect(p`{ name, ... }`({ name: "Fred", age: 12 })).toBe(true);
-  expect(p`{ name, age, ... }`({ name: "Fred", age: 12 })).toBe(true);
+it("should use exact matching", () => {
+  expect(p`{| name |}`({ name: "Fred" })).toBe(true);
+  expect(p`{| name |}`({ name: "Fred", age: 12 })).toBe(false);
+  expect(p`{| name, age |}`({ name: "Fred", age: 12 })).toBe(true);
+});
+
+it("should match exactly all the way down the object tree unless you use a rest", () => {
+  expect(
+    p`{| name, age, sub: { num: 100 } |}`({
+      name: "Fred",
+      age: 12,
+      sub: { num: 100 }
+    })
+  ).toBe(true);
+  expect(
+    p`{| name, age, sub: { num: 100 } |}`({
+      name: "Fred",
+      age: 12,
+      sub: { num: 100, foo: "foo" }
+    })
+  ).toBe(false);
+  expect(
+    p`{| name, age, sub: { num: 100, ... } |}`({
+      name: "Fred",
+      age: 12,
+      sub: { num: 100, foo: "foo" }
+    })
+  ).toBe(true);
+  expect(
+    p`{| name, age, sub: { num: 100, foo: { strict: true }, ... } |}`({
+      name: "Fred",
+      age: 12,
+      sub: {
+        num: 100,
+        foo: { strict: true, other: "stuff" },
+        bar: "bar"
+      }
+    })
+  ).toBe(false);
+  expect(
+    p`{| name, age, sub: { num: 100, foo: { strict: true }, ... } |}`({
+      name: "Fred",
+      age: 12,
+      sub: {
+        num: 100,
+        foo: { strict: true },
+        bar: "bar"
+      }
+    })
+  ).toBe(true);
 });
 
 it("should be able to use nested object property templates", () => {
@@ -339,10 +385,10 @@ it("should handle a wildcard", () => {
 });
 
 it("should respect a wildcard on an object", () => {
-  expect(p`{name: *}`({ name: undefined })).toBe(true);
-  expect(p`{name: *}`({ name: null })).toBe(true);
-  expect(p`{name: *}`({ name: false })).toBe(true);
-  expect(p`{name: *}`({})).toBe(false);
+  expect(p`{|name: *|}`({ name: undefined })).toBe(true);
+  expect(p`{|name: *|}`({ name: null })).toBe(true);
+  expect(p`{|name: *|}`({ name: false })).toBe(true);
+  expect(p`{|name: *|}`({})).toBe(false);
 });
 
 it("should handle greater than equals ", () => {

--- a/packages/pdsl/index.test.js
+++ b/packages/pdsl/index.test.js
@@ -147,6 +147,20 @@ it("should match exactly all the way down the object tree unless you use a rest"
       }
     })
   ).toBe(true);
+
+  expect(
+    p`{| name, age, sub: [{ num: 100, foo: { strict: true }, ... }] |}`({
+      name: "Fred",
+      age: 12,
+      sub: [
+        {
+          num: 100,
+          foo: { strict: true },
+          bar: "bar"
+        }
+      ]
+    })
+  ).toBe(true);
 });
 
 it("should be able to use nested object property templates", () => {


### PR DESCRIPTION
Closes #119 

This flips the default exact matching and instead adds a special exact matching object syntax: 

```js
expect(p`{ name }`({ name: "Fred", age: 12 })).toBe(true);
expect(p`{ name }`({ name: "Fred", age: 12 })).toBe(true);
expect(p`{ name, age }`({ name: "Fred", age: 12 })).toBe(true);
expect(p`{| name |}`({ name: "Fred" })).toBe(true);
expect(p`{| name |}`({ name: "Fred", age: 12 })).toBe(false);
expect(p`{| name, age |}`({ name: "Fred", age: 12 })).toBe(true);
```

Exact matching will continue all the way down an object tree: 

```js
expect(
    p`{| name, age, sub: { num: 100, foo: { strict: true }, ... } |}`({
      name: "Fred",
      age: 12,
      sub: {
        num: 100,
        foo: { strict: true, other: "stuff" },
        bar: "bar"
      }
    })
  ).toBe(false);
  expect(
    p`{| name, age, sub: { num: 100, foo: { strict: true }, ... } |}`({
      name: "Fred",
      age: 12,
      sub: {
        num: 100,
        foo: { strict: true },
        bar: "bar"
      }
    })
  ).toBe(true);
```