### PR TITLE
Update docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ PDSL provides the developer a simple but powerful shorthand based on a combinati
 
 ## UPDATE: Version 5 Breaking Changes
 
+### Exact matching off by default
+
 New in version 5.2+ objects no longer have exact matching turned on by default. If you wish to continue using exact matching you can use the [exact matching syntax](#objects-with-exact-matching-syntax):
 
 ```ts
@@ -52,10 +54,42 @@ p`{| message: "PDSL is awesome!" |}`({
 }); // false - because exact matching is specified
 ```
 
-Also new we have an [array includes](#array-includes) function:
+### New validation syntax
+
+We now have a new validation syntax!
 
 ```js
-p`[? > 50 ]`([1, 2, 100, 12]); // true because 100 is greater than 50
+import { schema } from "pdsl";
+
+const p = schema();
+
+const { validateSync: validUser } = p`{
+  name: string          <- "Name must be a string" 
+    & string[>7]        <- "Name must be longer than 7 characters",
+  age: (number & > 18)  <- "Age must be numeric and over 18"
+}`;
+
+try {
+  validUser({ name: "Rick" });
+} catch (err) {
+  expect(
+    p`{
+      message: "Name must be longer than 7 characters"
+    }`(err)
+  ).toBe(true);
+}
+```
+
+### New array includes syntax
+
+Also new we have an [array includes](#array-includes) function:
+
+```
+[? <predicate> ]
+```
+
+```js
+p`[? >50 ]`([1, 2, 100, 12]); // true because 100 is greater than 50
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ Creating predicate functions in JavaScript is often verbose, especially for chec
 
 PDSL provides the developer a simple but powerful shorthand based on a combination of template strings and helper functions for defining predicate functions that makes it easy to understand intent. With `pdsl` we can easily visualize the expected input's structure and intent using it's intuitive predicate composition language.
 
+## UPDATE: Version 5 Breaking Changes
+
+New in version 5.2+ objects no longer have exact matching turned on by default. If you wish to continue using exact matching you can use the [exact matching syntax](#objects-with-exact-matching-syntax):
+
+```ts
+p`{ message: "PDSL is awesome!" }`({
+  message: "PDSL is awesome!",
+  subject: "PDSL"
+}); // true - because exact matching is turned off by default
+
+p`{| message: "PDSL is awesome!" |}`({
+  message: "PDSL is awesome!",
+  subject: "PDSL"
+}); // false - because exact matching is specified
+```
+
+Also new we have an [array includes](#array-includes) function:
+
+```js
+p`[? > 50 ]`([1, 2, 100, 12]); // true because 100 is greater than 50
+```
+
 ## Examples
 
 PDSL doesn't really take much learning. Best thing to do is to look at a few examples.
@@ -97,24 +119,6 @@ This would be the same as using:
 const isObjWithName = p`{ name: _ }`;
 ```
 
-#### Exact matching syntax
-
-PDSL is exact matching by default which means the following:
-
-```js
-p`{ name }`({ name: "A name", age: 234 }); // false
-```
-
-However you can add a rest parameter to fix this:
-
-```js
-p`{ name, ... }`({
-  name: "A name",
-  age: 234,
-  occupation: "developer"
-}); // true
-```
-
 ### Array contains exact items
 
 ```js
@@ -126,10 +130,10 @@ p`[ number, string, *, { type: "SEVEN" } ]`([
 ]); // true
 ```
 
-### Typed Arrays 
+### Typed Arrays
 
 ```js
-p`Array<number>`([1,2,3,4]);
+p`Array<number>`([1, 2, 3, 4]);
 ```
 
 ### Number is part of range
@@ -225,16 +229,16 @@ The more complex things get, the more PDSL shines. See the above example in vani
 ```js
 const isValidUser = input =>
   input &&
-    input.username &&
-    typeof input.username === "string" &&
-    !input.username.match(/[^0-9]/) &&
-    !input.username.match(/[^A-Z]/) &&
-    input.username.length >= 4 &&
-    input.username.length <= 8 &&
-    typeof input.password === "string" &&
-    input.password.match(/[^a-zA-Z0-9]/) &&
-    input.password.length > 8 &&
-    input.age > 17;
+  input.username &&
+  typeof input.username === "string" &&
+  !input.username.match(/[^0-9]/) &&
+  !input.username.match(/[^A-Z]/) &&
+  input.username.length >= 4 &&
+  input.username.length <= 8 &&
+  typeof input.password === "string" &&
+  input.password.match(/[^a-zA-Z0-9]/) &&
+  input.password.length > 8 &&
+  input.age > 17;
 ```
 
 ### Complex Example
@@ -333,6 +337,15 @@ const isBoolean = p`${Boolean}`; // typeof value === 'boolean'
 const isString = p`${String}`; // typeof value === 'string'
 ```
 
+### Array includes
+
+You can check if an array includes an item by using the array includes syntax:
+
+```js
+p`[? 5]`([1, 2, 3, 4, 5]); // true
+p`[? 5]`([1, 2, 3, 4]); // false
+```
+
 ### Reference equality
 
 If you pass a value, `pdsl` will match that specific value:
@@ -396,7 +409,7 @@ validate({ name: 20 }); // false
 This applies to checking properties of all JavaScript objects. For example to check a string's length:
 
 ```js
-const validate = p`string & { length: 7, ... }`; // value && typeof value.name === 'string' && value.name.length === 7;
+const validate = p`string & { length: 7 }`; // value && typeof value.name === 'string' && value.name.length === 7;
 
 validate("Rudi"); // false
 validate("Yardley"); // true
@@ -443,6 +456,61 @@ const validate = p`{
 }`;
 
 validate({ name: "Hello", payload: { listening: true, num: 5 } }); // true
+```
+
+#### Objects with exact matching syntax
+
+PDSL is loose matches objects by default which means the following:
+
+```js
+p`{ name }`({ name: "A name", age: 234 }); // true
+```
+
+However you can specify exact matching by using `{|` and `|}` to represent your object:
+
+```js
+p`{| name |}`({ name: "A name", age: 234 }); // false
+p`{| name |}`({ name: "A name" }); // true
+```
+
+All nested normal objects will become exact matching too within the exact matching tokens:
+
+```js
+p`{|
+    name,
+    age,
+    sub: {
+      num: 100
+    }
+  |}`({
+  name: "Fred",
+  age: 12,
+  sub: {
+    num: 100,
+    foo: "foo"
+  }
+}); // false
+```
+
+If once you have enabled exact matching on an object you wish to have a loosely matched sub object you can use the rest operator to apply loose matching on that and that object only:
+
+```js
+p`{|
+    name,
+    age,
+    sub: {
+      num: 100,
+      ...
+    }
+  |}`({
+  name: "Fred",
+  age: 12,
+  sub: {
+    num: 100,
+    foo: "foo",
+    bar: "bar"
+  }
+}); // true
 ```
 
 ### Regular expression predicates
@@ -576,7 +644,14 @@ import { val, not, or, obj, entry, pred } from "pdsl/helpers";
 const notNil = val(not(or(val(null), val(undefined))));
 const hasName = val(obj("name"));
 const isTrue = val(true);
-const hasNameWithFn = val(obj(entry("name", pred(a => a.length > 10))));
+const hasNameWithFn = val(
+  obj(
+    entry(
+      "name",
+      pred(a => a.length > 10)
+    )
+  )
+);
 ```
 
 ## Roadmap
@@ -587,8 +662,9 @@ Help organise our priorities by [telling us what is the most important to you](h
 - [x] PDSL Compiler
 - [x] Comprehensive Test cases
 - [x] Babel Plugin to remove compiler perf overhead
-- [x] Exact matching by default
-- [ ] Validation errors
+- [x] ~~Exact matching by default~~ Reverted in v5
+- [x] Validation errors
+- [x] Exact matching syntax
 - [ ] Syntax Highlighting / VSCode Autocomplete / Prettier formatting
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -598,6 +598,10 @@ function doStuff(input: string | User) {
 }
 ```
 
+## Validation with Formik
+
+TBC.
+
 ## Helpers
 
 PDSL provides a number of helpers that can be exported from the `pdsl/helpers` package and may be used standalone or as part of a `p` expression.

--- a/README.md
+++ b/README.md
@@ -443,10 +443,17 @@ validate({ name: 20 }); // false
 This applies to checking properties of all JavaScript objects. For example to check a string's length:
 
 ```js
-const validate = p`string & { length: 7 }`; // value && typeof value.name === 'string' && value.name.length === 7;
+const validate = p`string & { length: 7 }`; // value && typeof value === 'string' && value.length === 7;
 
 validate("Rudi"); // false
 validate("Yardley"); // true
+```
+
+Note PDSL also provides a shorthand for checking string length:
+
+```js
+p`string[7]`("Robert"); // false
+p`string[7]`("Yardley"); // false
 ```
 
 Note you can now use `string[]` syntax to check a string's length.
@@ -600,7 +607,7 @@ function doStuff(input: string | User) {
 
 ## Validation with Formik
 
-TBC.
+TBC
 
 ## Helpers
 

--- a/packages/pdsl/errors.js
+++ b/packages/pdsl/errors.js
@@ -4,6 +4,7 @@ function ValidationError(message, path, inner, fileName, lineNumber) {
   instance.name = "ValidationError";
   instance.path = path;
   instance.inner = inner;
+  instance.message = message;
   Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
   return instance;
 }

--- a/packages/pdsl/grammar.js
+++ b/packages/pdsl/grammar.js
@@ -43,7 +43,7 @@ const tokens = {
   LOW_CHARS_REGX: "Lc",
   UP_CHARS_REGX: "Uc",
   LOW_UP_CHARS_REGX: "LUc",
-  VALIDATION_MSG: `::\\s*\\"((?:\\\\\\"|[^\\"])*)\\"`,
+  VALIDATION_MSG: `<-\\s*\\"((?:\\\\\\"|[^\\"])*)\\"`,
   EMPTY_OBJ: "\\{\\}",
   EMPTY_ARRAY: "\\[\\]",
   EMPTY_STRING_DOUBLE: `\\"\\"`,
@@ -586,7 +586,7 @@ const grammar = {
   }),
   [tokens.VALIDATION_MSG]: token => {
     const [, msg] = token.match(
-      /::\s*\"((?:\\\"|[^\"])*)\"/
+      /<-\s*\"((?:\\\"|[^\"])*)\"/
     ) || /* istanbul ignore next because it is tested in babel plugin */ [, ""];
 
     return {

--- a/packages/pdsl/index.test.js
+++ b/packages/pdsl/index.test.js
@@ -659,6 +659,12 @@ it("should be able to match array includes syntax", () => {
   expect(p`[? "four"]`([1, 2, "3", undefined, undefined])).toBe(false);
   expect(p`[? "four", "3"]`([1, 2, "3", undefined, undefined])).toBe(false);
   expect(p`[?1,"3"]`([1, 2, "3", undefined, undefined])).toBe(true);
+  expect(p`[? 5]`([1, 2, 3, 4, 5])).toBe(true);
+  expect(p`[? 5]`([1, 2, 3, 4])).toBe(false);
+  expect(p`[? 5 | "5"]`([1, 2, 3, 4, "5"])).toBe(true);
+  expect(p`[? 5 | "5"]`([1, 2, 3, 4, 50])).toBe(false);
+  expect(p`[? > 5]`([1, 2, 3, 4, 50])).toBe(true);
+  expect(p`[? > 5]`([1, 2, 3, 4])).toBe(false);
 });
 
 it("should match Array<type> syntax", () => {

--- a/packages/pdsl/index.test.js
+++ b/packages/pdsl/index.test.js
@@ -738,7 +738,7 @@ describe("validation", () => {
   });
 
   it("should be able to use var substitution in error messages", () => {
-    const expression = pdsl`>5 :: "Value $1 must be greater than 5!"`;
+    const expression = pdsl`>5 <- "Value $1 must be greater than 5!"`;
     expect(expression.unsafe_rpn()).toBe("5 > :e:Val:");
     expect(expression.validateSync(4)).toEqual([
       { path: "", message: "Value 4 must be greater than 5!" }
@@ -746,7 +746,7 @@ describe("validation", () => {
   });
 
   it("should be handle when var substitution is out of bounds", () => {
-    const expression = pdsl`>5 :: "Value $7 must be greater than 5!"`;
+    const expression = pdsl`>5 <- "Value $7 must be greater than 5!"`;
     expect(expression.unsafe_rpn()).toBe("5 > :e:Val:");
     expect(expression.validateSync(4)).toEqual([
       { path: "", message: "Value undefined must be greater than 5!" }
@@ -754,7 +754,7 @@ describe("validation", () => {
   });
 
   it("should be able to accept whitespace", () => {
-    const expression = pdsl`>5 ::     "Value must be greater than 5!   "`;
+    const expression = pdsl`>5 <-     "Value must be greater than 5!   "`;
     expect(expression.unsafe_rpn()).toBe("5 > :e:Val:");
     expect(expression.validateSync(4)).toEqual([
       { path: "", message: "Value must be greater than 5!" }
@@ -763,8 +763,8 @@ describe("validation", () => {
 
   it("should work on object properties", () => {
     const expression = pdsl`{
-      name: string :: "Name is not a string!",
-      age: number :: "Age is not a number!"
+      name: string <- "Name is not a string!",
+      age: number <- "Age is not a number!"
     }`;
 
     expect(expression.validateSync({ name: 1234, age: "12342134" })).toEqual([
@@ -780,7 +780,7 @@ describe("validation", () => {
   });
 
   it("should work on arrays", () => {
-    const expression = pdsl`[1,2,3] :: "Array is not [1,2,3]"`;
+    const expression = pdsl`[1,2,3] <- "Array is not [1,2,3]"`;
     expect(expression.validateSync([1, 2, 3, 4])).toEqual([
       { path: "", message: "Array is not [1,2,3]" }
     ]);
@@ -789,9 +789,9 @@ describe("validation", () => {
 
   it("should handle precedence and cling to whatever is before it", () => {
     const expression = pdsl`{
-      name: string               :: "Name must be a string"
-      & string[>7]               :: "Name must be longer than 7 characters",
-      age: (number & > 18)       :: "Age must be numeric and over 18"
+      name: string               <- "Name must be a string"
+      & string[>7]               <- "Name must be longer than 7 characters",
+      age: (number & > 18)       <- "Age must be numeric and over 18"
     }`;
 
     expect(expression.validateSync({ name: "12345678", age: 20 })).toEqual([]);
@@ -821,12 +821,44 @@ describe("validation", () => {
     ]);
   });
 
+  it("should throw the right errors", () => {
+    const expression = p.schema()`{
+      name: string               <- "Name must be a string"
+      & string[>7]               <- "Name must be longer than 7 characters",
+      age: (number & > 18)       <- "Age must be numeric and over 18"
+    }`.validateSync;
+
+    try {
+      expression({ name: "Foo", age: 20 });
+    } catch (err) {
+      expect(
+        p`{
+          path: "name", 
+          name: "ValidationError", 
+          message: "Name must be longer than 7 characters"
+        }`(err)
+      ).toBe(true);
+    }
+
+    try {
+      expression({ name: 123, age: 20 });
+    } catch (err) {
+      expect(
+        p`{
+          path: "name", 
+          name: "ValidationError", 
+          message: "Name must be a string"
+        }`(err)
+      ).toBe(true);
+    }
+  });
+
   it("should skip over all errors from OR decisions", () => {
     const expression = pdsl`({
-      name: string               :: "Name must be a string"
+      name: string               <- "Name must be a string"
     } | {
-      age: (number & > 18)       :: "Age must be numeric and over 18"
-    }) :: "You are not verified"`;
+      age: (number & > 18)       <- "Age must be numeric and over 18"
+    }) <- "You are not verified"`;
     expect(expression.validateSync({ name: 100 })).toEqual([
       { path: "name", message: "Name must be a string" },
       { path: "age", message: "Age must be numeric and over 18" },
@@ -843,7 +875,7 @@ describe("validation", () => {
   });
 
   it("should work with literal strings", () => {
-    const expression = pdsl`"hello" :: "This should be hello"`;
+    const expression = pdsl`"hello" <- "This should be hello"`;
     expect(expression.unsafe_rpn()).toBe('"hello" :e:Thi:');
     expect(expression.validateSync("nope")).toEqual([
       { path: "", message: "This should be hello" }
@@ -853,7 +885,7 @@ describe("validation", () => {
   it("should work with escaped quotes", () => {
     // Unfortunately because of the way template strings work we
     // have to use double backslash to escape quotes :(
-    const expression = pdsl`"hello" :: "This \\"should\\" be hello"`;
+    const expression = pdsl`"hello" <- "This \\"should\\" be hello"`;
 
     expect(expression.validateSync("nope")).toEqual([
       { path: "", message: 'This "should" be hello' }
@@ -862,12 +894,12 @@ describe("validation", () => {
 
   it("should work with nested objects", () => {
     const expression = pdsl`{
-      name: string               :: "Name must be a string",
-      age: (number & > 18)       :: "Age must be numeric and over 18",
+      name: string               <- "Name must be a string",
+      age: (number & > 18)       <- "Age must be numeric and over 18",
       school: {
-        type: "summer"           :: "Summer must be type",
-        thing: "winter"          :: "Winter must be thing"
-      }                          :: "School object problems"                         
+        type: "summer"           <- "Summer must be type",
+        thing: "winter"          <- "Winter must be thing"
+      }                          <- "School object problems"                         
     }`;
 
     expect(
@@ -900,7 +932,7 @@ describe("validation", () => {
 
   it("should validate object shorthands", () => {
     const expression = pdsl`{
-      name :: "Name is not provided!",
+      name <- "Name is not provided!",
     }`;
     expect(expression.validateSync({ name: undefined })).toEqual([
       {
@@ -912,8 +944,8 @@ describe("validation", () => {
 
   it("should validate asynchronously", async () => {
     const expression = pdsl`{
-      name: string :: "Name is not a string!",
-      age: number :: "Age is not a number!"
+      name: string <- "Name is not a string!",
+      age: number <- "Age is not a number!"
     }`;
 
     expect(await expression.validate({ name: "Fred", age: "16" })).toEqual([
@@ -926,9 +958,9 @@ describe("validation", () => {
 
   it("should throw errors that can be parsed by formik", async () => {
     const schema = p.schema({ throwErrors: true })`{
-      name: string :: "Name is not a string!",
-      age: number :: "Age is not a number!",
-      thing: _ :: "Thing is not null or undefined"
+      name: string <- "Name is not a string!",
+      age: number <- "Age is not a number!",
+      thing: _ <- "Thing is not null or undefined"
     }`;
 
     expect(schema.unsafe_rpn()).toBe(
@@ -985,8 +1017,8 @@ describe("validation", () => {
 
   it("should not have an inner property if there is only one error", async () => {
     const expression = p.schema({ throwErrors: true })`{
-      name: string :: "Name is not a string!",
-      age: number :: "Age is not a number!"
+      name: string <- "Name is not a string!",
+      age: number <- "Age is not a number!"
     }`;
 
     let myerror;
@@ -1011,6 +1043,9 @@ describe("validation", () => {
 
     it("should pass a sanity test", async () => {
       const schema = p.schema()`{ greeting: "Hello", object: "World" }`;
+
+      expect(schema.validate).not.toBeUndefined();
+      expect(schema.validateSync).not.toBeUndefined();
 
       let error;
       try {


### PR DESCRIPTION
Closes #110 

This also brings in arrow syntax for validations.

```js
p.schema()`{  name <- "Name must exist on this object" }`.validateSync({hello:'hello'})
```