### PR TITLE
Fix ORing number expr in str length not working

### DIFF
--- a/packages/docs/src/strings.md
+++ b/packages/docs/src/strings.md
@@ -31,8 +31,13 @@ p`string[5]`("1234"); // false
 
 You can also have any numeric test to apply to the strings length.
 
-```js
+```javascript
 p`string[<5]`("1234"); // true
+p`string[<5 | > 20]`("123456"); // false
+```
+
+```js
+p`string[<5]`("1234");
 ```
 
 ## Empty Strings

--- a/packages/pdsl/src/helpers/or.ts
+++ b/packages/pdsl/src/helpers/or.ts
@@ -22,6 +22,7 @@ export const createOr = ctx =>
       )(() => {
         const val = createVal(ctx);
         ctx.batchStart();
+
         const result = val(left)(a) || val(right)(a);
         if (!result) {
           ctx.batchCommit();

--- a/packages/pdsl/src/lib/index.test.ts
+++ b/packages/pdsl/src/lib/index.test.ts
@@ -414,6 +414,7 @@ it("should handle greater than ", () => {
   expect(p`>5`(6)).toBe(true);
   expect(p`>5`(5)).toBe(false);
   expect(p`{age:>5}`({ age: 34 })).toBe(true);
+  expect(p`string[<5 | >20]`("1234567")).toBe(false);
 });
 
 it("should handle a wildcard", () => {

--- a/packages/pdsl/src/lib/lexer.ts
+++ b/packages/pdsl/src/lib/lexer.ts
@@ -55,7 +55,7 @@ export function lexer(input) {
       // Remove closing string bracket to make
       // string[x] and array[x] a a unary operator
       // eg. "string[ > 7]" -> "string[ > 7"
-      .replace(/((?:string|array)\[)([^\]]*)(\])/g, "$1$2")
+      .replace(/((?:string|array)\[)([^\]]*)(\])/g, "$1($2)")
       // go and globally tokenise everything for parsing
       .match(rex)
       // convert to an object


### PR DESCRIPTION
Closes: #168 

What was happening was that the unary string length function `string[]` upon parsing needed to have its argument wrapped in a precedence operation.